### PR TITLE
Fix #5

### DIFF
--- a/pandoc_latex_color.py
+++ b/pandoc_latex_color.py
@@ -5,7 +5,8 @@ Pandoc filter for changing color in LaTeX
 """
 
 from panflute import run_filter, debug, Span, Div, \
-  RawInline, Inline, MetaInlines, MetaList
+  RawInline, Inline, MetaInlines, MetaList, \
+  RawBlock
 
 
 def x11colors():
@@ -194,31 +195,12 @@ def add_latex(elem, color, bgcolor):
 
     # Is it a Div?
     elif isinstance(elem, Div):
-
-        inlines = {'first': None, 'last': None}
-
-        def find_inlines(elem, _):
-            if isinstance(elem, Inline):
-                inlines['last'] = elem
-                if inlines['first'] is None:
-                    inlines['first'] = elem
-
-        elem.walk(find_inlines, None)
-
-        if inlines['first'] is not None:
-            if bgcolor:
-                inlines['first'].parent.content.insert(
-                    0,
-                    RawInline('{' + color + bgcolor + '\\hl{', 'tex')
-                )
-                inlines['last'].parent.content.append(RawInline('}}', 'tex'))
-            else:
-                inlines['first'].parent.content.insert(
-                    0,
-                    RawInline('{' + color, 'tex')
-                )
-                inlines['last'].parent.content.append(RawInline('}', 'tex'))
-
+        if bgcolor:
+            elem.content.insert(0, RawBlock('{' + color + bgcolor + '\\hl{', 'tex'))
+            elem.content.append(RawBlock('}', 'tex'))
+        else:
+            elem.content.insert(0, RawBlock('{' + color, 'tex'))
+            elem.content.append(RawBlock('}', 'tex'))
 
 def colorize(elem, doc):
     # Is it in the right format and is it a Span, Div, Code or CodeBlock?

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -44,8 +44,8 @@ def test_span_attributes():
 def div(elem, doc):
     pandoc_latex_color.main(doc)
     debug(elem.content)
-    opening(elem.content[0].content[0], RawInline)
-    closing(elem.content[0].content[-1], RawInline)
+    opening(elem.content[0], RawBlock)
+    closing(elem.content[-1], RawBlock)
 
 def test_div_classes():
     elem = Div(Para(Str('test')),classes=['class1', 'class2'])
@@ -54,6 +54,11 @@ def test_div_classes():
 
 def test_div_attributes():
     elem = Div(Para(Str('test')),attributes={'latex-color': 'red'})
+    doc = Doc(elem, format='latex', api_version=(1, 17, 2))
+    div(elem, doc)
+
+def test_div_multi():
+    elem = Div(Para(Str('test')), BlockQuote(Para(Str('test'))),attributes={'latex-color': 'red'})
     doc = Doc(elem, format='latex', api_version=(1, 17, 2))
     div(elem, doc)
 


### PR DESCRIPTION
This changes the behavior of filtering Divs to be similar to that of
Spans: we now add the raw Latex before and after the content of the
Div rather than adding it inline.

This fixes a bug described in the issue and also changes the behavior
in certain small ways. For example, previously in a list the first
bullet or number would not have its color changed (but later items
would), or horizontal rules at the start or end would not have their
color effected. Now everything enclosed in the Div is within the scope
of the color.